### PR TITLE
Fix TargetMode on Send Text Message

### DIFF
--- a/TentacleSoftware.TeamSpeakQuery/ServerQueryClient.cs
+++ b/TentacleSoftware.TeamSpeakQuery/ServerQueryClient.cs
@@ -356,7 +356,7 @@ namespace TentacleSoftware.TeamSpeakQuery
         public Task<ServerQueryBaseResult> SendTextMessage(TextMessageTargetMode targetMode, int targetId, string message)
         {
             return SendCommandAsync(new ServerQueryCommand<ServerQueryBaseResult>(Command.sendtextmessage)
-                .Add(Parameter.targetmode, targetMode)
+                .Add(Parameter.targetmode, (int)targetMode)
                 .Add(Parameter.target, targetId)
                 .Add(Parameter.msg, message));
         }


### PR DESCRIPTION
If you don't cast the enum value to an int it sends the following:

sendtextmessage targetmode=TextMessageTarget_CHANNEL target=1 msg=hi
error id=1540 msg=convert\serror
